### PR TITLE
Introduce CI tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.vo
 Makefile.coq
 Makefile.coq.conf
+result

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: nix
+
+script: nix-build --arg coq-version "\"$COQ_VERSION\"" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+
+env:
+  - COQ_VERSION=master
+  - COQ_VERSION=v8.8
+  - COQ_VERSION=8.8
+  - COQ_VERSION=8.7

--- a/R_addenda.v
+++ b/R_addenda.v
@@ -9,6 +9,7 @@
 (* This file contains various properties of R that are not in the standard library. *)
 
 Require Import Reals.
+Require Import Lra.
 Require Import Fourier.
 Require Import Euclid. 
 Require Import Omega.
@@ -556,8 +557,7 @@ Lemma conjRinv_range_l:forall r, 0<=r -> -1<=(3*r-1)/(r+1).
 Proof.
  intros r Hr;
  stepl (-1/1); [| field; apply R1_neq_R0];
- apply Rmult_Rdiv_pos_Rle; try fourier.
- rewrite Rmult_plus_distr_l; do 2 rewrite Rmult_1_r; fourier.
+ apply Rmult_Rdiv_pos_Rle; lra.
 Qed.
 
 Lemma conjMinv_range_r:forall r, r <= 1/3 -> 3*r<=1.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,16 @@
+{ coq-version ? "master" }:
+
+let coq = {
+  "master" = import (fetchTarball "https://github.com/coq/coq/tarball/master") {};
+  "v8.8" = import (fetchTarball "https://github.com/coq/coq/tarball/v8.8") {};
+  "8.8" = (import <nixpkgs> {}).coq_8_8;
+  "8.7" = (import <nixpkgs> {}).coq_8_7;
+  }."${coq-version}";
+in
+
+(import <nixpkgs> {}).stdenv.mkDerivation rec {
+  name = "qarith-stern-brocot";
+  buildInputs = [ coq ];
+  src = ./.;
+  installFlags = "DESTDIR=$(out)/lib/coq/";
+}


### PR DESCRIPTION
I have delayed a bit my submission of this PR because of FLOC even if it was ready for a while.

This is a new way of running CI on Coq packages which uses Nix instead of OPAM to install the dependencies (especially Coq). This uses some infrastructure that has been put in Coq so that the compilation output of building Coq using Nix is saved, so the major advantage for external projects like this one will be that CI will run very fast as it will download a binary version of Coq (including for the master branch) and only recompile the project itself. Thus running CI for this project should only take a few minutes.