### PR TITLE
Naming fixes for 8.14 and later

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,8 +17,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:8.13'
-          - 'coqorg/coq:8.12'
+          - 'coqorg/coq:dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ field operations on them in two different ways: strict and lazy.
 - Coq-community maintainer(s):
   - Hugo Herbelin ([**@herbelin**](https://github.com/herbelin))
 - License: [GNU Lesser General Public License v2.1 or later](LICENSE)
-- Compatible Coq versions: 8.12 or 8.13
+- Compatible Coq versions: 8.14 or later
 - Additional dependencies: none
 - Coq namespace: `QArithSternBrocot`
 - Related publication(s):

--- a/coq-qarith-stern-brocot.opam
+++ b/coq-qarith-stern-brocot.opam
@@ -19,7 +19,7 @@ field operations on them in two different ways: strict and lazy.
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.12" & < "8.14~"}
+  "coq" {(>= "8.14" & < "8.15~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -33,12 +33,11 @@ license:
   identifier: LGPL-2.1-or-later
 
 supported_coq_versions:
-  text: 8.12 or 8.13
-  opam: '{>= "8.12" & < "8.14~"}'
+  text: 8.14 or later
+  opam: '{(>= "8.14" & < "8.15~") | (= "dev")}'
 
 tested_coq_opam_versions:
-- version: '8.13'
-- version: '8.12'
+- version: dev
 
 namespace: QArithSternBrocot
 

--- a/theories/Qhomographic_Qpositive_to_Q_properties.v
+++ b/theories/Qhomographic_Qpositive_to_Q_properties.v
@@ -399,7 +399,7 @@ generalize
 
  rewrite
   (Qhomographic_Qpositive_to_Q_0 a b c 0 p H_Qhomographic_sg_denom_nonzero2
-     Hc _x (refl_equal 0%Z)).
+     Hc a0 (refl_equal 0%Z)).
  apply fraction_encoding_equal.
  Falsum.
 generalize
@@ -409,41 +409,35 @@ generalize
 
  rewrite
   (Qhomographic_Qpositive_to_Q_0 a b c 0 p H_Qhomographic_sg_denom_nonzero2
-     Hc _x (refl_equal 0%Z)).
+     Hc a0 (refl_equal 0%Z)).
  apply fraction_encoding_equal.
  Falsum.
 
  (* 2 *)
  rewrite
   (Qhomographic_Qpositive_to_Q_1 a b c d p H_Qhomographic_sg_denom_nonzero2
-     d_neq_zero _x).
+     b0 a0).
  apply fraction_encoding_equal.
  (* 3 *)
  clear e0.
  rewrite
   (h_sign_equal a b c d p H_Qhomographic_sg_denom_nonzero1
-     H_Qhomographic_sg_denom_nonzero2) in _x.
+     H_Qhomographic_sg_denom_nonzero2) in a1.
  rewrite
   (Qhomographic_Qpositive_to_Q_2 a b c d p H_Qhomographic_sg_denom_nonzero2
-     ad_neq_bc _x).
+     b0 a1).
  reflexivity.
  (* 4 *)
 
  Clear_eq_.
  generalize
   (Qhomographic_Qpositive_to_Q_homographicAcc_pos_1 a b c d p
-     H_Qhomographic_sg_denom_nonzero1 ad_neq_bc l1_eq_one z).
- assert (l1_eq_one0 := l1_eq_one).
+     H_Qhomographic_sg_denom_nonzero1 b0 b1 a1).
+ assert (l1_eq_one0 := b1).
  rewrite
   (h_sign_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in l1_eq_one0.
- change
-   (0 <
-    Z.sgn
-      (new_a a b c d p H_Qhomographic_sg_denom_nonzero1 +
-       new_b a b c d p H_Qhomographic_sg_denom_nonzero1))%Z 
-  in z. 
- assert (z0 := z).
+ assert (z0 := a1).
  rewrite (new_a_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in z0.
  rewrite
@@ -451,9 +445,9 @@ generalize
      H_Qhomographic_sg_denom_nonzero2) in z0.
  rewrite
   (Qhomographic_Qpositive_to_Q_3 a b c d p H_Qhomographic_sg_denom_nonzero2
-     ad_neq_bc l1_eq_one0
+     b0 l1_eq_one0
      (Qhomographic_Qpositive_to_Q_homographicAcc_pos_1 a b c d p
-        H_Qhomographic_sg_denom_nonzero2 ad_neq_bc l1_eq_one0 z0) z0)
+        H_Qhomographic_sg_denom_nonzero2 b0 l1_eq_one0 z0) z0)
   .
  intro H_any_homographicAcc.
  apply f_equal with Qpositive.
@@ -478,17 +472,12 @@ generalize
  Clear_eq_.
  generalize
   (Qhomographic_Qpositive_to_Q_homographicAcc_pos_2 a b c d p
-     H_Qhomographic_sg_denom_nonzero1 ad_neq_bc l1_eq_one z).
- assert (l1_eq_one0 := l1_eq_one).
+     H_Qhomographic_sg_denom_nonzero1 b0 b1 b2).
+ assert (l1_eq_one0 := b1).
  rewrite
   (h_sign_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in l1_eq_one0.
- change
-   (Z.sgn
-      (new_a a b c d p H_Qhomographic_sg_denom_nonzero1 +
-       new_b a b c d p H_Qhomographic_sg_denom_nonzero1) <= 0)%Z 
-  in z. 
- assert (z0 := z).
+ assert (z0 := b2).
  rewrite
   (new_a_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in z0.
@@ -497,9 +486,9 @@ generalize
      H_Qhomographic_sg_denom_nonzero2) in z0.
  rewrite
   (Qhomographic_Qpositive_to_Q_4 a b c d p H_Qhomographic_sg_denom_nonzero2
-     ad_neq_bc l1_eq_one0
+     b0 l1_eq_one0
      (Qhomographic_Qpositive_to_Q_homographicAcc_pos_2 a b c d p
-        H_Qhomographic_sg_denom_nonzero2 ad_neq_bc l1_eq_one0 z0) z0)
+        H_Qhomographic_sg_denom_nonzero2 b0 l1_eq_one0 z0) z0)
   .
  intro H_any_homographicAcc.
  apply f_equal with Qpositive.
@@ -523,17 +512,12 @@ generalize
  Clear_eq_.
  generalize
   (Qhomographic_Qpositive_to_Q_homographicAcc_neg_1 a b c d p
-     H_Qhomographic_sg_denom_nonzero1 ad_neq_bc l1_eq__minus_one z).
- assert (l1_eq__minus_one0 := l1_eq__minus_one).
+     H_Qhomographic_sg_denom_nonzero1 b0 b1 a0).
+ assert (l1_eq__minus_one0 := b1).
  rewrite
   (h_sign_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in l1_eq__minus_one0.
- change
-   (Z.sgn
-      (new_a a b c d p H_Qhomographic_sg_denom_nonzero1 +
-       new_b a b c d p H_Qhomographic_sg_denom_nonzero1) < 0)%Z 
-  in z. 
- assert (z0 := z).
+ assert (z0 := a0).
  rewrite
   (new_a_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in z0.
@@ -542,9 +526,9 @@ generalize
      H_Qhomographic_sg_denom_nonzero2) in z0.
  rewrite
   (Qhomographic_Qpositive_to_Q_5 a b c d p H_Qhomographic_sg_denom_nonzero2
-     ad_neq_bc l1_eq__minus_one0
+     b0 l1_eq__minus_one0
      (Qhomographic_Qpositive_to_Q_homographicAcc_neg_1 a b c d p
-        H_Qhomographic_sg_denom_nonzero2 ad_neq_bc l1_eq__minus_one0 z0) z0)
+        H_Qhomographic_sg_denom_nonzero2 b0 l1_eq__minus_one0 z0) z0)
   .
  intro H_any_homographicAcc.
  apply f_equal with Qpositive.
@@ -568,18 +552,12 @@ generalize
  Clear_eq_.
  generalize
   (Qhomographic_Qpositive_to_Q_homographicAcc_neg_2 a b c d p
-     H_Qhomographic_sg_denom_nonzero1 ad_neq_bc l1_eq__minus_one z).
- assert (l1_eq__minus_one0 := l1_eq__minus_one).
+     H_Qhomographic_sg_denom_nonzero1 b0 b1 b2).
+ assert (l1_eq__minus_one0 := b1).
  rewrite
   (h_sign_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in l1_eq__minus_one0.
- change
-   (0 <=
-    Z.sgn
-      (new_a a b c d p H_Qhomographic_sg_denom_nonzero1 +
-       new_b a b c d p H_Qhomographic_sg_denom_nonzero1))%Z 
-  in z. 
- assert (z0:=z).
+ assert (z0:=b2).
  rewrite
   (new_a_equal a b c d p H_Qhomographic_sg_denom_nonzero1
      H_Qhomographic_sg_denom_nonzero2) in z0.
@@ -588,9 +566,9 @@ generalize
      H_Qhomographic_sg_denom_nonzero2) in z0.
  rewrite
   (Qhomographic_Qpositive_to_Q_6 a b c d p H_Qhomographic_sg_denom_nonzero2
-     ad_neq_bc l1_eq__minus_one0
+     b0 l1_eq__minus_one0
      (Qhomographic_Qpositive_to_Q_homographicAcc_neg_2 a b c d p
-        H_Qhomographic_sg_denom_nonzero2 ad_neq_bc l1_eq__minus_one0 z0) z0)
+        H_Qhomographic_sg_denom_nonzero2 b0 l1_eq__minus_one0 z0) z0)
   .
  intro H_any_homographicAcc.
  apply f_equal with Qpositive.

--- a/theories/Qquadratic_Qpositive_to_Q_properties.v
+++ b/theories/Qquadratic_Qpositive_to_Q_properties.v
@@ -13,7 +13,6 @@
 (* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA *)
 (* 02110-1301 USA                                                     *)
 
-
 Require Import FunInd.
 Require Export Qquadratic.
 Require Import homographic_correctness.
@@ -820,26 +819,26 @@ Proof.
  (* 1 *)
  rewrite
   (Qquadratic_Qpositive_to_Q_3 _ _ _ _ _ _ _ _ _ _
-     H_Qquadratic_sg_denom_nonzero2 He _x); reflexivity.
+     H_Qquadratic_sg_denom_nonzero2 a3 a0); reflexivity.
  (* 2 *)
  rewrite
   (Qquadratic_Qpositive_to_Q_2 _ _ _ _ _ _ _ _ _ _
-     H_Qquadratic_sg_denom_nonzero2 Hf _x); reflexivity.
- (* 3 *)
+     H_Qquadratic_sg_denom_nonzero2 b0 a0); reflexivity.
+ (* 3 *) 
  rewrite
   (Qquadratic_Qpositive_to_Q_1 _ _ _ _ _ _ _ _ _ _
-     H_Qquadratic_sg_denom_nonzero2 Hg _x); reflexivity.
+     H_Qquadratic_sg_denom_nonzero2 b0 a0); reflexivity.
  (* 4 *)
  rewrite
   (Qquadratic_Qpositive_to_Q_0 _ _ _ _ _ _ _ _ _ _
-     H_Qquadratic_sg_denom_nonzero2 Hh _x); reflexivity.
+     H_Qquadratic_sg_denom_nonzero2 b0 a0); reflexivity.
  (* 5 *)
  rewrite
   (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero1
-     H_Qquadratic_sg_denom_nonzero2) in _x;
+     H_Qquadratic_sg_denom_nonzero2) in a1;
   rewrite
    (Qquadratic_Qpositive_to_Q_4 _ _ _ _ _ _ _ _ _ _
-      H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh _x)
+      H_Qquadratic_sg_denom_nonzero2 b0 a1)
    ; reflexivity.
  (* 6 *)
  Absurd_q_sign_.
@@ -865,15 +864,15 @@ Proof.
         H_Qquadratic_sg_denom_nonzero1); assumption.
    rewrite
     (Qquadratic_Qpositive_to_Q_5 _ _ _ _ _ _ _ _ _ _
-       H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+       H_Qquadratic_sg_denom_nonzero2 b0
        (trans_eq
           (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-             H_Qquadratic_sg_denom_nonzero1) l1_eq_one) H
+             H_Qquadratic_sg_denom_nonzero1) b1) H
        (Qquadratic_Qpositive_to_Q_quadraticAcc_pos_1 _ _ _ _ _ _ _ _ _ _
-          H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+          H_Qquadratic_sg_denom_nonzero2 b0
           (trans_eq
              (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-                H_Qquadratic_sg_denom_nonzero1) l1_eq_one) H))
+                H_Qquadratic_sg_denom_nonzero1) b1) H))
     ; apply f_equal with Qpositive;
     apply Qquadratic_Qpositive_to_Qpositive_equal_strong;
     [ apply qnew_a_equal
@@ -909,15 +908,15 @@ Proof.
         H_Qquadratic_sg_denom_nonzero1); assumption.
    rewrite
     (Qquadratic_Qpositive_to_Q_6 _ _ _ _ _ _ _ _ _ _
-       H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+       H_Qquadratic_sg_denom_nonzero2 b0
        (trans_eq
           (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-             H_Qquadratic_sg_denom_nonzero1) l1_eq_one) H
+             H_Qquadratic_sg_denom_nonzero1) b1) H
        (Qquadratic_Qpositive_to_Q_quadraticAcc_pos_2 _ _ _ _ _ _ _ _ _ _
-          H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+          H_Qquadratic_sg_denom_nonzero2 b0
           (trans_eq
              (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-                H_Qquadratic_sg_denom_nonzero1) l1_eq_one) H))
+                H_Qquadratic_sg_denom_nonzero1) b1) H))
     .
    apply f_equal with Qpositive;
     apply Qquadratic_Qpositive_to_Qpositive_equal_strong;
@@ -956,15 +955,15 @@ Proof.
         H_Qquadratic_sg_denom_nonzero1); assumption.
    rewrite
     (Qquadratic_Qpositive_to_Q_7 _ _ _ _ _ _ _ _ _ _
-       H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+       H_Qquadratic_sg_denom_nonzero2 b0
        (trans_eq
           (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-             H_Qquadratic_sg_denom_nonzero1) l1_eq_min_one) H
+             H_Qquadratic_sg_denom_nonzero1) b1) H
        (Qquadratic_Qpositive_to_Q_quadraticAcc_neg_1 _ _ _ _ _ _ _ _ _ _
-          H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+          H_Qquadratic_sg_denom_nonzero2 b0
           (trans_eq
              (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-                H_Qquadratic_sg_denom_nonzero1) l1_eq_min_one) H))
+                H_Qquadratic_sg_denom_nonzero1) b1) H))
     .
    apply f_equal with Qpositive;
     apply Qquadratic_Qpositive_to_Qpositive_equal_strong;
@@ -1002,15 +1001,15 @@ Proof.
         H_Qquadratic_sg_denom_nonzero1); assumption.
    rewrite
     (Qquadratic_Qpositive_to_Q_8 _ _ _ _ _ _ _ _ _ _
-       H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+       H_Qquadratic_sg_denom_nonzero2 b0
        (trans_eq
           (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-             H_Qquadratic_sg_denom_nonzero1) l1_eq_min_one) H
+             H_Qquadratic_sg_denom_nonzero1) b1) H
        (Qquadratic_Qpositive_to_Q_quadraticAcc_neg_2 _ _ _ _ _ _ _ _ _ _
-          H_Qquadratic_sg_denom_nonzero2 not_same_ratio_abcdefgh
+          H_Qquadratic_sg_denom_nonzero2 b0
           (trans_eq
              (q_sign_equal a b c d _ _ _ _ _ _ H_Qquadratic_sg_denom_nonzero2
-                H_Qquadratic_sg_denom_nonzero1) l1_eq_min_one) H))
+                H_Qquadratic_sg_denom_nonzero1) b1) H))
     .
    apply f_equal with Qpositive;
     apply Qquadratic_Qpositive_to_Qpositive_equal_strong;

--- a/theories/homographic_correctness.v
+++ b/theories/homographic_correctness.v
@@ -210,7 +210,7 @@ Proof.
  functional induction (Qmult y x); intros.
  (* Qneg 0: 1 *)
  apply False_ind.
- apply (Zorder.Zlt_not_eq _ _ z).
+ apply (Zorder.Zlt_not_eq _ _ a0).
  rewrite <- Zsgn_15.
  apply Zsgn_6.
  rewrite Z_eq_mult; try reflexivity.
@@ -224,7 +224,7 @@ Proof.
  symmetry  in |- *; assumption.
  (* Qneg Qpos : 1 *)
  apply False_ind.
- apply (Zlt_asym _ _ z).
+ apply (Zlt_asym _ _ a0).
  rewrite <- Zsgn_15.
  apply Zsgn_26.
  assert (Hm : (0 < m)%Z);
@@ -293,7 +293,7 @@ Proof.
  apply Qlt_zero_pos.
  (* Qneg Qpos : 2 *)
  apply False_ind.
- apply (Zlt_asym _ _ z).
+ apply (Zlt_asym _ _ a0).
  rewrite <- Zsgn_15.
  apply Zsgn_26.
  assert (Hm : (m < 0)%Z);
@@ -315,7 +315,7 @@ Proof.
  functional induction (Qmult y x); intros.
  (* Qpos 0: 1 *)
  apply False_ind.
- generalize (Z.gt_lt _ _ z); clear z; intro z.
+ generalize (Z.gt_lt _ _ b); clear b; intro z.
  apply (Zorder.Zlt_not_eq _ _ z).
  symmetry  in |- *.
  rewrite <- Zsgn_15.
@@ -355,7 +355,7 @@ Proof.
  apply Qlt_zero_pos.
  (* Qpos Qneg : 1 *)
  apply False_ind.
- generalize (Z.gt_lt _ _ z); clear z; intro z.
+ generalize (Z.gt_lt _ _ b); clear b; intro z.
  apply (Zlt_asym _ _ z).
  rewrite <- Zsgn_15.
  apply Zsgn_27.
@@ -376,7 +376,7 @@ Proof.
  symmetry  in |- *; assumption.
  (* Qpos Qneg : 2 *)
  apply False_ind.
- generalize (Z.gt_lt _ _ z); clear z; intro z.
+ generalize (Z.gt_lt _ _ b); clear b; intro z.
  apply (Zlt_asym _ _ z).
  rewrite <- Zsgn_15.
  apply Zsgn_27.
@@ -636,7 +636,7 @@ Proof.
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
  simpl in |- *.
- generalize (Zsgn_21 _ _ _x1) (Zsgn_23 _ _ _x1) (Zsgn_19 _ _ _x1);
+ generalize (Zsgn_21 _ _ a1) (Zsgn_23 _ _ a1) (Zsgn_19 _ _ a1);
   intros Hc_nonneg Hd_nonneg Hcd_pos.
  replace (Qsgn (Qplus (Qmult c (Qpos (nR q))) d)) with 1%Z.
  rewrite Qsgn_29.
@@ -666,7 +666,7 @@ Proof.
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
  simpl in |- *.
- generalize (Zsgn_22 _ _ _x2) (Zsgn_24 _ _ _x2) (Zsgn_20 _ _ _x2);
+ generalize (Zsgn_22 _ _ a1) (Zsgn_24 _ _ a1) (Zsgn_20 _ _ a1);
   intros Hc_nonpos Hd_nonpos Hcd_neg.
  replace (Qsgn (Qplus (Qmult c (Qpos (nR q))) d)) with (-1)%Z.
  rewrite Qsgn_29.
@@ -700,7 +700,7 @@ Proof.
  rewrite Qsgn_28.
  rewrite Qsgn_15.
  simpl in |- *.
- generalize (Zsgn_21 _ _ _x1) (Zsgn_23 _ _ _x1) (Zsgn_19 _ _ _x1);
+ generalize (Zsgn_21 _ _ a1) (Zsgn_23 _ _ a1) (Zsgn_19 _ _ a1);
   intros Ha_nonneg Hb_nonneg Hab_pos.
  replace (Qsgn (Qplus (Qmult a (Qpos (nR q))) b)) with 1%Z.
  rewrite Qsgn_29.
@@ -732,7 +732,7 @@ Proof.
  rewrite Qsgn_28.
  rewrite Qsgn_15.
  simpl in |- *.
- generalize (Zsgn_22 _ _ _x2) (Zsgn_24 _ _ _x2) (Zsgn_20 _ _ _x2);
+ generalize (Zsgn_22 _ _ a1) (Zsgn_24 _ _ a1) (Zsgn_20 _ _ a1);
   intros Ha_nonpos Hb_nonpos Hab_neg.
  replace (Qsgn (Qplus (Qmult a (Qpos (nR q))) b)) with (-1)%Z.
  rewrite Qsgn_29.
@@ -761,7 +761,7 @@ Proof.
   clear e2 e0 e1  .
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
- case (inside_interval_1_inf _ _ _x1); clear _x1;
+ case (inside_interval_1_inf _ _ a0); clear a0;
   intros (Hab, Hcd);
   repeat
    match goal with
@@ -820,10 +820,10 @@ Proof.
      | apply Z_to_Q_neg; assumption ] ].
  (* (nR9) : b<>0 & d<>0 & ~(i1 o1 o2) & (i2 o1 o2)*)
  unfold spec_Qhomographic_Qpositive_to_Q in |- *;
-  clear e3 e0 e1 e2  _x1.
+  clear e3 e0 e1 e2 b2.
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
- case (inside_interval_2_inf _ _ _x2); clear _x2;
+ case (inside_interval_2_inf _ _ a0); clear a0;
   intros (Hab, Hcd);
   repeat
    match goal with
@@ -917,7 +917,7 @@ Proof.
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
  simpl in |- *.
- generalize (Zsgn_21 _ _ _x1) (Zsgn_23 _ _ _x1) (Zsgn_19 _ _ _x1);
+ generalize (Zsgn_21 _ _ a1) (Zsgn_23 _ _ a1) (Zsgn_19 _ _ a1);
   intros Hc_nonneg Hd_nonneg Hcd_pos.
  replace (Qsgn (Qplus (Qmult c (Qpos (dL q))) d)) with 1%Z.
  rewrite Qsgn_29.
@@ -947,7 +947,7 @@ Proof.
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
  simpl in |- *.
- generalize (Zsgn_22 _ _ _x2) (Zsgn_24 _ _ _x2) (Zsgn_20 _ _ _x2);
+ generalize (Zsgn_22 _ _ a1) (Zsgn_24 _ _ a1) (Zsgn_20 _ _ a1);
   intros Hc_nonpos Hd_nonpos Hcd_neg.
  replace (Qsgn (Qplus (Qmult c (Qpos (dL q))) d)) with (-1)%Z.
  rewrite Qsgn_29.
@@ -981,7 +981,7 @@ Proof.
  rewrite Qsgn_28.
  rewrite Qsgn_15.
  simpl in |- *.
- generalize (Zsgn_21 _ _ _x1) (Zsgn_23 _ _ _x1) (Zsgn_19 _ _ _x1);
+ generalize (Zsgn_21 _ _ a1) (Zsgn_23 _ _ a1) (Zsgn_19 _ _ a1);
   intros Ha_nonneg Hb_nonneg Hab_pos.
  replace (Qsgn (Qplus (Qmult a (Qpos (dL q))) b)) with 1%Z.
  rewrite Qsgn_29.
@@ -1013,7 +1013,7 @@ Proof.
  rewrite Qsgn_28.
  rewrite Qsgn_15.
  simpl in |- *.
- generalize (Zsgn_22 _ _ _x2) (Zsgn_24 _ _ _x2) (Zsgn_20 _ _ _x2);
+ generalize (Zsgn_22 _ _ a1) (Zsgn_24 _ _ a1) (Zsgn_20 _ _ a1);
   intros Ha_nonpos Hb_nonpos Hab_neg.
  replace (Qsgn (Qplus (Qmult a (Qpos (dL q))) b)) with (-1)%Z.
  rewrite Qsgn_29.
@@ -1042,7 +1042,7 @@ Proof.
   clear e2 e0 e1  .
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
- case (inside_interval_1_inf _ _ _x1); clear _x1;
+ case (inside_interval_1_inf _ _ a0); clear a0;
   intros (Hab, Hcd);
   repeat
    match goal with
@@ -1101,10 +1101,10 @@ Proof.
      | apply Z_to_Q_neg; assumption ] ].
  (* (dL9) : b<>0 & d<>0 & ~(i1 o1 o2) & (i2 o1 o2)*)
  unfold spec_Qhomographic_Qpositive_to_Q in |- *;
-  clear e3 e0 e1 e2  _x1.
+  clear e3 e0 e1 e2 b2.
  repeat rewrite Qsgn_15.  
  rewrite Qsgn_28.
- case (inside_interval_2_inf _ _ _x2); clear _x2;
+ case (inside_interval_2_inf _ _ a0); clear a0;
   intros (Hab, Hcd);
   repeat
    match goal with
@@ -1184,7 +1184,7 @@ Proof.
  unfold spec_Qhomographic_Qpositive_to_Q in |- *; clear e1 e0 ;
   rewrite Qsgn_15; repeat rewrite Qmult_one_right;
   rewrite Qsgn_28; repeat rewrite <- Z_to_Qplus; repeat rewrite Qsgn_29;
-     rewrite <- _x1; rewrite <- Zsgn_15; symmetry  in |- *; 
+     rewrite <- a0; rewrite <- Zsgn_15; symmetry  in |- *; 
   apply Zsgn_7'; abstract auto with zarith.
  (* (One2) : (Z.sgn (a+b))<>0 & (Z.sgn (a+b))<>(Z.sgn (c+d)) *)
  unfold spec_Qhomographic_Qpositive_to_Q in |- *; clear e1 e0;
@@ -1195,11 +1195,10 @@ Proof.
              (Qhomographic_signok_1 _ _ _x));
            intro Hcd_; generalize (Zsgn_1' (a + b)) (Zsgn_1' (c + d));
              intros [[Hab| Hab]| Hab] [[Hcd| Hcd]| Hcd]; 
-               try solve [ Falsum ]; rewrite Hab in _x1; 
-		 rewrite Hcd in _x1; try solve [ Falsum ]; 
+               try solve [ Falsum ]; rewrite Hab in b1; 
+		 rewrite Hcd in b1; try solve [ Falsum ]; 
 		   rewrite Hab; rewrite Hcd; constructor).
 Defined.
-
 
 Lemma homographicAcc_positive :
  forall (a b c d : Z) (p : Qpositive),
@@ -1627,9 +1626,9 @@ Proof.
    (Qhomographic_Qpositive_to_Q a b c d p H_Qhomographic_sg_denom_nonzero).
 
  (* 1 *)
- clear e e0 e1 .
+ clear e e0 e1.
  rename x into Hc0;
- rename _x into ad_eq_bc;
+ rename a0 into ad_eq_bc;
    rewrite coding_Q.
  assert (b0_eq_zero : b = 0%Z).
  rewrite Zmult_0_r in ad_eq_bc.
@@ -1646,8 +1645,8 @@ Proof.
                          *)
                    rewrite <- Qdiv_num_denom; [ reflexivity | discriminate ]) .
  clear e e0 e1.
- rename H into Hc0;
- rename _x into ad_eq_bc;
+ rename x into Hc0;
+ rename a0 into ad_eq_bc;
    rewrite coding_Q.
  assert (b0_eq_zero : b = 0%Z).
  rewrite Zmult_0_r in ad_eq_bc.

--- a/theories/quadratic_correctness.v
+++ b/theories/quadratic_correctness.v
@@ -13,7 +13,6 @@
 (* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA *)
 (* 02110-1301 USA                                                     *)
 
-
 Require Import FunInd.
 Require Export homographic_correctness.
 Require Import Field_Theory_Q. 
@@ -3229,7 +3228,7 @@ Proof.
  (* 1 *)
  rewrite coding_Q.
  unfold spec_fraction_encoding in |- *.
- generalize _x; intros (H1, (H2, (H3, (H4, (H5, H6)))));
+ generalize a0; intros (H1, (H2, (H3, (H4, (H5, H6)))));
   repeat
    match goal with
    | id1:(_ = _ :>Z) |- _ =>
@@ -3245,7 +3244,7 @@ Proof.
  (* 2 *)
  rewrite coding_Q.
  unfold spec_fraction_encoding in |- *.
- generalize _x; intros (H1, (H2, (H3, (H4, (H5, H6)))));
+ generalize a0; intros (H1, (H2, (H3, (H4, (H5, H6)))));
   repeat
    match goal with
    | id1:(_ = _ :>Z) |- _ =>
@@ -3261,7 +3260,7 @@ Proof.
  (* 3 *)
  rewrite coding_Q.
  unfold spec_fraction_encoding in |- *.
- generalize _x; intros (H1, (H2, (H3, (H4, (H5, H6)))));
+ generalize a0; intros (H1, (H2, (H3, (H4, (H5, H6)))));
   repeat
    match goal with
    | id1:(_ = _ :>Z) |- _ =>
@@ -3277,7 +3276,7 @@ Proof.
  (* 4 *)
  rewrite coding_Q.
  unfold spec_fraction_encoding in |- *.
- generalize _x; intros (H1, (H2, (H3, (H4, (H5, H6)))));
+ generalize a0; intros (H1, (H2, (H3, (H4, (H5, H6)))));
   repeat
    match goal with
    | id1:(_ = _ :>Z) |- _ =>


### PR DESCRIPTION
Due to changes in functional induction name generation, it's infeasible to be compatible with both 8.13 and 8.14. Here, we switch to compatibility with 8.14 and later. 